### PR TITLE
Fix "`@:extern` is deprecated in favor of `extern`" warning on Haxe 4.3.7

### DIFF
--- a/hxbitmini/Macros.hx
+++ b/hxbitmini/Macros.hx
@@ -812,8 +812,8 @@ class Macros {
 						}),
 					},{
 						name : "serialize",
-						access : [AInline, APublic],
-						meta : [{name:":extern",pos:pos}],
+						access : [AInline, APublic, AExtern],
+						meta : [],
 						pos : pos,
 						kind : FFun( {
 							args : [{ name : "ctx", type : macro : hxbitmini.Serializer },{ name : "v", type : pt.toComplexType() }],
@@ -822,8 +822,8 @@ class Macros {
 						}),
 					},{
 						name : "unserialize",
-						access : [AInline, APublic],
-						meta : [{name:":extern",pos:pos}],
+						access : [AInline, APublic, AExtern],
+						meta : [],
 						pos : pos,
 						kind : FFun( {
 							args : [{ name : "ctx", type : macro : hxbitmini.Serializer }],

--- a/hxbitmini/Serializer.hx
+++ b/hxbitmini/Serializer.hx
@@ -242,7 +242,7 @@ class Serializer {
 		}
 	}
 
-	@:extern public inline function getMap<K,T>(fk:Void->K, ft:Void->T) : Map<K,T> {
+	extern public inline function getMap<K,T>(fk:Void->K, ft:Void->T) : Map<K,T> {
 		var len = getInt();
 		if( len == 0 )
 			#if hxbitmini_nullsafety


### PR DESCRIPTION
This small PR fixes a deprecation warning that appears on semi-recent Haxe versions:

`hxbitmini/Macros.hx:315: character 25 : Warning : (WDeprecated) '@:extern' is deprecated in favor of 'extern'`

@kyubuns if you have the time, I'd really appreciate this :pray: 